### PR TITLE
added vs_folder param to specify a completely custom trash directory

### DIFF
--- a/src/vscode_deleted_file_recovery/__init__.py
+++ b/src/vscode_deleted_file_recovery/__init__.py
@@ -54,9 +54,11 @@ def get_vscode_path():
 
 class Recover:
     @staticmethod
-    def print_files(search_term):
+    def print_files(search_term, vs_folder = ''):
+        base_folder = os.path.expanduser(vs_folder)
+        if not len(base_folder):
+          base_folder = get_vscode_path()
         xs = []
-        base_folder = get_vscode_path()
         for folder in os.listdir(base_folder):
             if not folder.startswith("_recovery"):
                 entries_path = os.path.join(base_folder, folder, 'entries.json')
@@ -70,10 +72,12 @@ class Recover:
             print(x)
 
     @staticmethod
-    def restore_files(search_term):
-        vs_folder = get_vscode_path()
-        base_folder = os.getcwd()
+    def restore_files(search_term, vs_folder = ''):
+        vs_folder = os.path.expanduser(vs_folder)
+        if not len(vs_folder):
+          vs_folder = get_vscode_path()
 
+        base_folder = os.getcwd()
         for folder in os.listdir(vs_folder):
             if not folder.startswith("_recovery"):
                 entries_path = os.path.join(vs_folder, folder, 'entries.json')


### PR DESCRIPTION
I added an optional parameter to the search and restore function to define a custom location for the trash folder (bypassing the auto-detection).

Example:
`Recover.print_files(search_term='/project',vs_folder='~/.vscode-server/data/User/History')`